### PR TITLE
Store request, response, and history per handler

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 1.82,
-      functions: 1.36,
-      lines: 1.66,
-      statements: 1.51,
+      branches: 98.78,
+      functions: 90.05,
+      lines: 92.25,
+      statements: 92.28,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 98.82,
-      functions: 92.36,
-      lines: 92.66,
-      statements: 92.51,
+      branches: 1.82,
+      functions: 1.36,
+      lines: 1.66,
+      statements: 1.51,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '**/*.html' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepack": "./scripts/prepack.sh",
     "start": "webpack serve --mode development",
-    "test": "jest && jest-it-up",
+    "test": "jest && jest-it-up --margin 0.5",
     "test:watch": "jest --watch"
   },
   "simple-git-hooks": {

--- a/src/features/handlers/components/Response.tsx
+++ b/src/features/handlers/components/Response.tsx
@@ -1,11 +1,26 @@
 import { Center, Heading, Text } from '@chakra-ui/react';
+import { HandlerType } from '@metamask/snaps-utils';
+import { assert } from '@metamask/utils';
+import { useMatch } from 'react-router-dom';
 
 import { Editor, Icon } from '../../../components';
 import { useSelector } from '../../../hooks';
-import { getResponse } from '../../simulation';
 
 export const Response = () => {
-  const response = useSelector(getResponse);
+  const match = useMatch('/handler/:handlerId');
+  const handlerId = match?.params.handlerId;
+
+  assert(handlerId, 'The handler ID should be defined.');
+
+  const response = useSelector(
+    (state) =>
+      state[
+        handlerId as
+          | HandlerType.OnCronjob
+          | HandlerType.OnRpcRequest
+          | HandlerType.OnTransaction
+      ].response,
+  );
 
   if (!response) {
     return (

--- a/src/features/handlers/cronjobs/components/Request.tsx
+++ b/src/features/handlers/cronjobs/components/Request.tsx
@@ -10,9 +10,10 @@ import { FunctionComponent } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { Editor } from '../../../../components';
-import { useDispatch } from '../../../../hooks';
+import { useDispatch, useSelector } from '../../../../hooks';
 import { sendRequest } from '../../../simulation';
 import { SAMPLE_JSON_RPC_REQUEST } from '../../json-rpc/schema';
+import { getCronjobRequest } from '../slice';
 
 type CronjobFormData = {
   origin: string;
@@ -20,6 +21,7 @@ type CronjobFormData = {
 };
 
 export const Request: FunctionComponent = () => {
+  const { request, origin } = useSelector(getCronjobRequest);
   const {
     handleSubmit,
     register,
@@ -27,8 +29,10 @@ export const Request: FunctionComponent = () => {
     formState: { errors },
   } = useForm<CronjobFormData>({
     defaultValues: {
-      origin: '',
-      request: SAMPLE_JSON_RPC_REQUEST,
+      origin: origin ?? '',
+      request: request
+        ? JSON.stringify(request, null, 2)
+        : SAMPLE_JSON_RPC_REQUEST,
     },
   });
 

--- a/src/features/handlers/cronjobs/index.ts
+++ b/src/features/handlers/cronjobs/index.ts
@@ -1,1 +1,2 @@
 export * from './Cronjobs';
+export * from './slice';

--- a/src/features/handlers/cronjobs/slice.test.ts
+++ b/src/features/handlers/cronjobs/slice.test.ts
@@ -1,0 +1,38 @@
+import {
+  cronjob as reducer,
+  INITIAL_STATE,
+  setCronjobRequest,
+  setCronjobResponse,
+} from './slice';
+
+describe('cronjobs', () => {
+  describe('setCronjobRequest', () => {
+    it('sets the request', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setCronjobRequest({ origin: 'foo' }),
+      );
+
+      expect(result.request).toStrictEqual({ origin: 'foo' });
+    });
+
+    it('pushes the request to history', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setCronjobRequest({ origin: 'foo' }),
+      );
+
+      expect(result.history).toStrictEqual([
+        { date: expect.any(Date), request: { origin: 'foo' } },
+      ]);
+    });
+  });
+
+  describe('setCronjobResponse', () => {
+    it('sets the response', () => {
+      const result = reducer(INITIAL_STATE, setCronjobResponse('foo'));
+
+      expect(result.response).toBe('foo');
+    });
+  });
+});

--- a/src/features/handlers/cronjobs/slice.ts
+++ b/src/features/handlers/cronjobs/slice.ts
@@ -11,15 +11,17 @@ type Request = {
 
 type Response = string;
 
+export const INITIAL_STATE = {
+  request: {
+    origin: '',
+  },
+  response: null,
+  history: [],
+};
+
 const slice = createHandlerSlice<Request, Response>({
   name: HandlerType.OnCronjob,
-  initialState: {
-    request: {
-      origin: '',
-    },
-    response: null,
-    history: [],
-  },
+  initialState: INITIAL_STATE,
 });
 
 export const cronjob = slice.reducer;

--- a/src/features/handlers/cronjobs/slice.ts
+++ b/src/features/handlers/cronjobs/slice.ts
@@ -1,0 +1,35 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { JsonRpcRequest } from '@metamask/utils';
+import { createSelector } from '@reduxjs/toolkit';
+
+import { createHandlerSlice } from '../slice';
+
+type Request = {
+  origin: string;
+  request?: JsonRpcRequest;
+};
+
+type Response = string;
+
+const slice = createHandlerSlice<Request, Response>({
+  name: HandlerType.OnCronjob,
+  initialState: {
+    request: {
+      origin: '',
+    },
+    response: '',
+    history: [],
+  },
+});
+
+export const cronjob = slice.reducer;
+export const {
+  setRequest: setCronjobRequest,
+  setResponse: setCronjobResponse,
+} = slice.actions;
+
+export const getCronjobRequest = createSelector(
+  (state: { cronjob: ReturnType<typeof slice['getInitialState']> }) =>
+    state.cronjob,
+  (state) => state.request,
+);

--- a/src/features/handlers/index.ts
+++ b/src/features/handlers/index.ts
@@ -1,3 +1,3 @@
-export * from './cronjobs';
-export * from './json-rpc';
-export * from './transactions';
+export { Cronjobs, cronjob } from './cronjobs';
+export { JsonRpc, jsonRpc } from './json-rpc';
+export { Transactions, transactions } from './transactions';

--- a/src/features/handlers/json-rpc/components/Request.tsx
+++ b/src/features/handlers/json-rpc/components/Request.tsx
@@ -10,9 +10,10 @@ import { FunctionComponent } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { Editor } from '../../../../components';
-import { useDispatch } from '../../../../hooks';
+import { useDispatch, useSelector } from '../../../../hooks';
 import { sendRequest } from '../../../simulation';
 import { SAMPLE_JSON_RPC_REQUEST } from '../schema';
+import { getJsonRpcRequest } from '../slice';
 
 type JsonRpcFormData = {
   origin: string;
@@ -20,6 +21,7 @@ type JsonRpcFormData = {
 };
 
 export const Request: FunctionComponent = () => {
+  const { request, origin } = useSelector(getJsonRpcRequest);
   const {
     handleSubmit,
     register,
@@ -27,8 +29,10 @@ export const Request: FunctionComponent = () => {
     formState: { errors },
   } = useForm<JsonRpcFormData>({
     defaultValues: {
-      origin: '',
-      request: SAMPLE_JSON_RPC_REQUEST,
+      origin: origin ?? '',
+      request: request
+        ? JSON.stringify(request, null, 2)
+        : SAMPLE_JSON_RPC_REQUEST,
     },
   });
 

--- a/src/features/handlers/json-rpc/index.ts
+++ b/src/features/handlers/json-rpc/index.ts
@@ -1,1 +1,2 @@
 export * from './JsonRpc';
+export * from './slice';

--- a/src/features/handlers/json-rpc/schema.ts
+++ b/src/features/handlers/json-rpc/schema.ts
@@ -30,11 +30,13 @@ export const JSON_RPC_SCHEMA = {
   additionalProperties: false,
 };
 
-export const SAMPLE_JSON_RPC_REQUEST = `
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "subtract",
-  "params": [42, 23]
-}
-`.trimStart();
+export const SAMPLE_JSON_RPC_REQUEST = JSON.stringify(
+  {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'subtract',
+    params: [42, 23],
+  },
+  null,
+  2,
+);

--- a/src/features/handlers/json-rpc/slice.test.ts
+++ b/src/features/handlers/json-rpc/slice.test.ts
@@ -1,0 +1,38 @@
+import {
+  jsonRpc as reducer,
+  setJsonRpcRequest,
+  setJsonRpcResponse,
+  INITIAL_STATE,
+} from './slice';
+
+describe('jsonRpc', () => {
+  describe('setJsonRpcRequest', () => {
+    it('sets the request', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setJsonRpcRequest({ origin: 'foo' }),
+      );
+
+      expect(result.request).toStrictEqual({ origin: 'foo' });
+    });
+
+    it('pushes the request to history', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setJsonRpcRequest({ origin: 'foo' }),
+      );
+
+      expect(result.history).toStrictEqual([
+        { date: expect.any(Date), request: { origin: 'foo' } },
+      ]);
+    });
+  });
+
+  describe('setJsonRpcResponse', () => {
+    it('sets the response', () => {
+      const result = reducer(INITIAL_STATE, setJsonRpcResponse('foo'));
+
+      expect(result.response).toBe('foo');
+    });
+  });
+});

--- a/src/features/handlers/json-rpc/slice.ts
+++ b/src/features/handlers/json-rpc/slice.ts
@@ -1,0 +1,35 @@
+import { HandlerType } from '@metamask/snaps-utils';
+import { JsonRpcRequest } from '@metamask/utils';
+import { createSelector } from '@reduxjs/toolkit';
+
+import { createHandlerSlice } from '../slice';
+
+type Request = {
+  origin: string;
+  request?: JsonRpcRequest;
+};
+
+type Response = string;
+
+const slice = createHandlerSlice<Request, Response>({
+  name: HandlerType.OnRpcRequest,
+  initialState: {
+    request: {
+      origin: '',
+    },
+    response: '',
+    history: [],
+  },
+});
+
+export const jsonRpc = slice.reducer;
+export const {
+  setRequest: setJsonRpcRequest,
+  setResponse: setJsonRpcResponse,
+} = slice.actions;
+
+export const getJsonRpcRequest = createSelector(
+  (state: { jsonRpc: ReturnType<typeof slice['getInitialState']> }) =>
+    state.jsonRpc,
+  (state) => state.request,
+);

--- a/src/features/handlers/json-rpc/slice.ts
+++ b/src/features/handlers/json-rpc/slice.ts
@@ -11,15 +11,17 @@ type Request = {
 
 type Response = string;
 
+export const INITIAL_STATE = {
+  request: {
+    origin: '',
+  },
+  response: null,
+  history: [],
+};
+
 const slice = createHandlerSlice<Request, Response>({
   name: HandlerType.OnRpcRequest,
-  initialState: {
-    request: {
-      origin: '',
-    },
-    response: null,
-    history: [],
-  },
+  initialState: INITIAL_STATE,
 });
 
 export const jsonRpc = slice.reducer;

--- a/src/features/handlers/json-rpc/slice.ts
+++ b/src/features/handlers/json-rpc/slice.ts
@@ -17,7 +17,7 @@ const slice = createHandlerSlice<Request, Response>({
     request: {
       origin: '',
     },
-    response: '',
+    response: null,
     history: [],
   },
 });
@@ -29,7 +29,8 @@ export const {
 } = slice.actions;
 
 export const getJsonRpcRequest = createSelector(
-  (state: { jsonRpc: ReturnType<typeof slice['getInitialState']> }) =>
-    state.jsonRpc,
+  (state: {
+    [HandlerType.OnRpcRequest]: ReturnType<typeof slice['getInitialState']>;
+  }) => state[HandlerType.OnRpcRequest],
   (state) => state.request,
 );

--- a/src/features/handlers/slice.ts
+++ b/src/features/handlers/slice.ts
@@ -1,0 +1,51 @@
+import { createSlice, Draft, PayloadAction } from '@reduxjs/toolkit';
+
+export type HandlerSliceOptions<Request, Response> = {
+  name: string;
+  initialState: HandlerState<Request, Response>;
+};
+
+export type HistoryEntry<Request> = {
+  date: Date;
+  request: Request;
+};
+
+export type HandlerState<Request, Response> = {
+  request: Request;
+  response: Response;
+  history: HistoryEntry<Request>[];
+};
+
+/**
+ * Create a slice for a handler.
+ *
+ * @param options - Options for the slice.
+ * @param options.name - The name of the slice.
+ * @param options.initialState - The initial state of the slice.
+ * @returns The slice.
+ */
+export function createHandlerSlice<Request, Response>({
+  name,
+  initialState,
+}: HandlerSliceOptions<Request, Response>) {
+  const slice = createSlice({
+    name,
+    initialState,
+    reducers: {
+      setRequest: (state, action: PayloadAction<Request>) => {
+        // `immer` does not work well with generic types, so we have to cast.
+        state.request = action.payload as Draft<Request>;
+        state.history.push({
+          date: new Date(),
+          request: action.payload as Draft<Request>,
+        });
+      },
+      setResponse: (state, action: PayloadAction<Response>) => {
+        // `immer` does not work well with generic types, so we have to cast.
+        state.response = action.payload as Draft<Response>;
+      },
+    },
+  });
+
+  return slice;
+}

--- a/src/features/handlers/slice.ts
+++ b/src/features/handlers/slice.ts
@@ -12,7 +12,7 @@ export type HistoryEntry<Request> = {
 
 export type HandlerState<Request, Response> = {
   request: Request;
-  response: Response;
+  response: Response | null;
   history: HistoryEntry<Request>[];
 };
 

--- a/src/features/handlers/transactions/index.ts
+++ b/src/features/handlers/transactions/index.ts
@@ -1,1 +1,2 @@
 export * from './Transactions';
+export * from './slice';

--- a/src/features/handlers/transactions/slice.test.ts
+++ b/src/features/handlers/transactions/slice.test.ts
@@ -1,0 +1,38 @@
+import {
+  transactions as reducer,
+  setTransactionRequest,
+  INITIAL_STATE,
+  setTransactionResponse,
+} from './slice';
+
+describe('transactions', () => {
+  describe('setTransactionRequest', () => {
+    it('sets the request', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setTransactionRequest({ origin: 'foo' }),
+      );
+
+      expect(result.request).toStrictEqual({ origin: 'foo' });
+    });
+
+    it('pushes the request to history', () => {
+      const result = reducer(
+        INITIAL_STATE,
+        setTransactionRequest({ origin: 'foo' }),
+      );
+
+      expect(result.history).toStrictEqual([
+        { date: expect.any(Date), request: { origin: 'foo' } },
+      ]);
+    });
+  });
+
+  describe('setTransactionResponse', () => {
+    it('sets the response', () => {
+      const result = reducer(INITIAL_STATE, setTransactionResponse('foo'));
+
+      expect(result.response).toBe('foo');
+    });
+  });
+});

--- a/src/features/handlers/transactions/slice.ts
+++ b/src/features/handlers/transactions/slice.ts
@@ -12,7 +12,7 @@ type Request = {
 type Response = string;
 
 const slice = createHandlerSlice<Request, Response>({
-  name: HandlerType.OnCronjob,
+  name: HandlerType.OnTransaction,
   initialState: {
     request: {
       origin: '',
@@ -22,15 +22,15 @@ const slice = createHandlerSlice<Request, Response>({
   },
 });
 
-export const cronjob = slice.reducer;
+export const transactions = slice.reducer;
 export const {
-  setRequest: setCronjobRequest,
-  setResponse: setCronjobResponse,
+  setRequest: setTransactionRequest,
+  setResponse: setTransactionResponse,
 } = slice.actions;
 
-export const getCronjobRequest = createSelector(
+export const getTransactionRequest = createSelector(
   (state: {
-    [HandlerType.OnCronjob]: ReturnType<typeof slice['getInitialState']>;
-  }) => state[HandlerType.OnCronjob],
+    [HandlerType.OnTransaction]: ReturnType<typeof slice['getInitialState']>;
+  }) => state[HandlerType.OnTransaction],
   (state) => state.request,
 );

--- a/src/features/handlers/transactions/slice.ts
+++ b/src/features/handlers/transactions/slice.ts
@@ -11,15 +11,17 @@ type Request = {
 
 type Response = string;
 
+export const INITIAL_STATE = {
+  request: {
+    origin: '',
+  },
+  response: null,
+  history: [],
+};
+
 const slice = createHandlerSlice<Request, Response>({
   name: HandlerType.OnTransaction,
-  initialState: {
-    request: {
-      origin: '',
-    },
-    response: null,
-    history: [],
-  },
+  initialState: INITIAL_STATE,
 });
 
 export const transactions = slice.reducer;

--- a/src/features/navigation/items.ts
+++ b/src/features/navigation/items.ts
@@ -1,3 +1,5 @@
+import { HandlerType } from '@metamask/snaps-utils';
+
 import { IconName } from '../../components';
 import { ApplicationState } from '../../store';
 
@@ -23,20 +25,20 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
     tag: 'onRpcRequest',
     description: 'Send JSON-RPC requests to the snap',
     icon: 'textBubble',
-    path: '/handler/json-rpc',
+    path: `/handler/${HandlerType.OnRpcRequest}`,
   },
   {
     label: 'Cronjobs',
     tag: 'onCronjob',
     description: 'Schedule and run periodic actions',
     icon: 'alert',
-    path: '/handler/cronjobs',
+    path: `/handler/${HandlerType.OnCronjob}`,
   },
   {
     label: 'Transaction',
     tag: 'onTransaction',
     description: 'Send transactions to the snap',
     icon: 'textBubble',
-    path: '/handler/transactions',
+    path: `/handler/${HandlerType.OnTransaction}`,
   },
 ];

--- a/src/features/simulation/sagas.test.ts
+++ b/src/features/simulation/sagas.test.ts
@@ -12,7 +12,6 @@ import {
   requestSaga,
 } from './sagas';
 import {
-  captureResponse,
   sendRequest,
   setExecutionService,
   setManifest,
@@ -67,8 +66,15 @@ describe('requestSaga', () => {
       .withState({
         simulation: { sourceCode, executionService },
       })
+      .put({
+        type: `${HandlerType.OnRpcRequest}/setRequest`,
+        payload: request,
+      })
       .call([executionService, 'handleRpcRequest'], DEFAULT_SNAP_ID, request)
-      .put(captureResponse({ result: 'foobar' }))
+      .put({
+        type: `${HandlerType.OnRpcRequest}/setResponse`,
+        payload: 'foobar',
+      })
       .silentRun();
   });
 });

--- a/src/features/simulation/sagas.ts
+++ b/src/features/simulation/sagas.ts
@@ -29,7 +29,6 @@ import {
   setExecutionService,
   setSourceCode,
   sendRequest,
-  captureResponse,
   SnapStatus,
   setStatus,
   getPermissionController,
@@ -157,6 +156,7 @@ export function* rebootSaga({ payload }: PayloadAction<string>) {
  * @yields Select for selecting the execution service, call to call the execution service and put for storing the response.
  */
 export function* requestSaga({ payload }: PayloadAction<SnapRpcHookArgs>) {
+  yield put({ type: `${payload.handler}/setRequest`, payload });
   const executionService: IframeExecutionService = yield select(
     getExecutionService,
   );
@@ -167,9 +167,13 @@ export function* requestSaga({ payload }: PayloadAction<SnapRpcHookArgs>) {
       DEFAULT_SNAP_ID,
       payload,
     );
-    yield put(captureResponse({ result }));
+
+    yield put({ type: `${payload.handler}/setResponse`, payload: result });
   } catch (error) {
-    yield put(captureResponse({ error: serializeError(error) }));
+    yield put({
+      type: `${payload.handler}/setResponse`,
+      payload: { error: serializeError(error) },
+    });
   }
 }
 

--- a/src/features/simulation/slice.test.ts
+++ b/src/features/simulation/slice.test.ts
@@ -1,11 +1,8 @@
 import { IframeExecutionService } from '@metamask/snaps-controllers';
-import { HandlerType } from '@metamask/snaps-utils';
 
 import {
   SnapStatus,
-  captureResponse,
   simulation as reducer,
-  sendRequest,
   setExecutionService,
   setManifest,
   setSourceCode,
@@ -50,27 +47,6 @@ describe('simulation slice', () => {
       const result = reducer(INITIAL_STATE, setManifest(MOCK_MANIFEST));
 
       expect(result.manifest).toBe(MOCK_MANIFEST);
-    });
-  });
-
-  describe('sendRequest', () => {
-    it('sets the request', () => {
-      const request = {
-        origin: 'Snaps Simulator',
-        handler: HandlerType.OnRpcRequest,
-        request: { jsonrpc: '2.0', method: 'foo', params: [] },
-      };
-      const result = reducer(INITIAL_STATE, sendRequest(request));
-
-      expect(result.request).toStrictEqual(request);
-    });
-  });
-
-  describe('captureResponse', () => {
-    it('sets the response', () => {
-      const result = reducer(INITIAL_STATE, captureResponse({ result: 'foo' }));
-
-      expect(result.response).toStrictEqual({ result: 'foo' });
     });
   });
 });

--- a/src/features/simulation/slice.ts
+++ b/src/features/simulation/slice.ts
@@ -1,7 +1,12 @@
 import { GenericPermissionController } from '@metamask/permission-controller';
 import { IframeExecutionService } from '@metamask/snaps-controllers';
 import { SnapManifest, SnapRpcHookArgs } from '@metamask/snaps-utils';
-import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  createAction,
+  createSelector,
+  createSlice,
+  PayloadAction,
+} from '@reduxjs/toolkit';
 
 export enum SnapStatus {
   Ok,
@@ -15,8 +20,6 @@ type SimulationState = {
   permissionController: GenericPermissionController | null;
   manifest: SnapManifest | null;
   sourceCode: string;
-  request: SnapRpcHookArgs | null;
-  response: unknown | null;
 };
 
 export const INITIAL_STATE: SimulationState = {
@@ -25,8 +28,6 @@ export const INITIAL_STATE: SimulationState = {
   permissionController: null,
   manifest: null,
   sourceCode: '',
-  request: null,
-  response: null,
 };
 
 const slice = createSlice({
@@ -52,14 +53,12 @@ const slice = createSlice({
     setSourceCode(state, action: PayloadAction<string>) {
       state.sourceCode = action.payload;
     },
-    sendRequest(state, action: PayloadAction<SnapRpcHookArgs>) {
-      state.request = action.payload;
-    },
-    captureResponse(state, action: PayloadAction<unknown>) {
-      state.response = action.payload;
-    },
   },
 });
+
+export const sendRequest = createAction<SnapRpcHookArgs>(
+  `${slice.name}/sendRequest`,
+);
 
 export const {
   setStatus,
@@ -67,9 +66,8 @@ export const {
   setPermissionController,
   setManifest,
   setSourceCode,
-  sendRequest,
-  captureResponse,
 } = slice.actions;
+
 export const simulation = slice.reducer;
 
 export const getStatus = createSelector(
@@ -90,9 +88,4 @@ export const getPermissionController = createSelector(
 export const getChecksum = createSelector(
   (state: { simulation: typeof INITIAL_STATE }) => state.simulation,
   (state) => state.manifest?.source.shasum,
-);
-
-export const getResponse = createSelector(
-  (state: { simulation: typeof INITIAL_STATE }) => state.simulation,
-  (state) => state.response,
 );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,3 +1,4 @@
+import { HandlerType } from '@metamask/snaps-utils';
 import {
   createHashRouter,
   createRoutesFromElements,
@@ -13,12 +14,26 @@ export const router = createHashRouter(
     <Route element={<Layout />}>
       <Route
         path="/"
-        element={<Navigate to="/handler/json-rpc" replace={true} />}
+        element={
+          <Navigate
+            to={`/handler/${HandlerType.OnRpcRequest}`}
+            replace={true}
+          />
+        }
       />
       <Route path="/handler" element={<Handler />}>
-        <Route path="/handler/json-rpc" element={<JsonRpc />} />
-        <Route path="/handler/cronjobs" element={<Cronjobs />} />
-        <Route path="/handler/transactions" element={<Transactions />} />
+        <Route
+          path={`/handler/${HandlerType.OnRpcRequest}`}
+          element={<JsonRpc />}
+        />
+        <Route
+          path={`/handler/${HandlerType.OnCronjob}`}
+          element={<Cronjobs />}
+        />
+        <Route
+          path={`/handler/${HandlerType.OnTransaction}`}
+          element={<Transactions />}
+        />
       </Route>
     </Route>,
   ),

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { simulation, configuration } from '../features';
+import { simulation, configuration, jsonRpc, cronjob } from '../features';
 
 export const reducer = combineReducers({
   configuration,
   simulation,
+  jsonRpc,
+  cronjob,
 });

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,10 +1,18 @@
+import { HandlerType } from '@metamask/snaps-utils';
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { simulation, configuration, jsonRpc, cronjob } from '../features';
+import {
+  simulation,
+  configuration,
+  jsonRpc,
+  cronjob,
+  transactions,
+} from '../features';
 
 export const reducer = combineReducers({
   configuration,
   simulation,
-  jsonRpc,
-  cronjob,
+  [HandlerType.OnRpcRequest]: jsonRpc,
+  [HandlerType.OnCronjob]: cronjob,
+  [HandlerType.OnTransaction]: transactions,
 });


### PR DESCRIPTION
Rather than storing a global request, response, and history, we want to store it per handler. This adds a slice per handler which stores the state.