### PR TITLE
Improve tab handling

### DIFF
--- a/src/features/handlers/components/Handler.tsx
+++ b/src/features/handlers/components/Handler.tsx
@@ -74,7 +74,12 @@ export const Handler: FunctionComponent = () => {
           borderLeft="1px solid"
           borderColor="border.default"
         >
-          <Tabs display="flex" flexDirection="column" flex="1">
+          <Tabs
+            display="flex"
+            flexDirection="column"
+            flex="1"
+            overflow="hidden"
+          >
             <ResetTab />
             <ResetUserInterfaceTab />
 
@@ -82,7 +87,12 @@ export const Handler: FunctionComponent = () => {
               <Tab>Response</Tab>
               {userInterface && <Tab>UI</Tab>}
             </TabList>
-            <TabPanels display="flex" flexDirection="column" flex="1">
+            <TabPanels
+              display="flex"
+              flexDirection="column"
+              flex="1"
+              overflow="hidden"
+            >
               <TabPanel
                 display="flex"
                 flexDirection="column"
@@ -92,7 +102,7 @@ export const Handler: FunctionComponent = () => {
                 <Response />
               </TabPanel>
               {userInterface && (
-                <TabPanel>
+                <TabPanel overflowY="auto">
                   <UserInterface />
                 </TabPanel>
               )}

--- a/src/features/handlers/components/Handler.tsx
+++ b/src/features/handlers/components/Handler.tsx
@@ -10,13 +10,18 @@ import {
 import { FunctionComponent, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import { useSelector } from '../../../hooks';
+import { getUserInterface } from '../../simulation';
 import { History } from './History';
 import { PlayButton } from './PlayButton';
+import { ResetTab } from './ResetTab';
+import { ResetUserInterfaceTab } from './ResetUserInterfaceTab';
 import { Response } from './Response';
 import { UserInterface } from './UserInterface';
 
 export const Handler: FunctionComponent = () => {
   const [tab, setTab] = useState(0);
+  const userInterface = useSelector(getUserInterface);
 
   return (
     <Flex width="100%" direction="column" overflow="hidden">
@@ -30,6 +35,7 @@ export const Handler: FunctionComponent = () => {
             isLazy={true}
             onChange={setTab}
           >
+            <ResetTab />
             <TabList alignItems="center">
               <Tab>Request</Tab>
               <Tab>History</Tab>
@@ -69,9 +75,12 @@ export const Handler: FunctionComponent = () => {
           borderColor="border.default"
         >
           <Tabs display="flex" flexDirection="column" flex="1">
+            <ResetTab />
+            <ResetUserInterfaceTab />
+
             <TabList>
               <Tab>Response</Tab>
-              <Tab>UI</Tab>
+              {userInterface && <Tab>UI</Tab>}
             </TabList>
             <TabPanels display="flex" flexDirection="column" flex="1">
               <TabPanel
@@ -82,9 +91,11 @@ export const Handler: FunctionComponent = () => {
               >
                 <Response />
               </TabPanel>
-              <TabPanel>
-                <UserInterface />
-              </TabPanel>
+              {userInterface && (
+                <TabPanel>
+                  <UserInterface />
+                </TabPanel>
+              )}
             </TabPanels>
           </Tabs>
         </Box>

--- a/src/features/handlers/components/ResetTab.tsx
+++ b/src/features/handlers/components/ResetTab.tsx
@@ -1,0 +1,20 @@
+import { useTabsContext } from '@chakra-ui/react';
+import { FunctionComponent, useEffect } from 'react';
+
+import { useHandler } from '../../../hooks';
+
+/**
+ * Resets the tab to the first tab when the handler changes.
+ *
+ * @returns `null`.
+ */
+export const ResetTab: FunctionComponent = () => {
+  const handler = useHandler();
+  const tab = useTabsContext();
+
+  useEffect(() => {
+    tab.setSelectedIndex(0);
+  }, [handler]);
+
+  return null;
+};

--- a/src/features/handlers/components/ResetUserInterfaceTab.tsx
+++ b/src/features/handlers/components/ResetUserInterfaceTab.tsx
@@ -1,0 +1,23 @@
+import { useTabsContext } from '@chakra-ui/react';
+import { FunctionComponent, useEffect } from 'react';
+
+import { useSelector } from '../../../hooks';
+import { getUserInterface } from '../../simulation';
+
+/**
+ * Resets the tab to the first tab when the user interface is closed.
+ *
+ * @returns `null`.
+ */
+export const ResetUserInterfaceTab: FunctionComponent = () => {
+  const userInterface = useSelector(getUserInterface);
+  const tab = useTabsContext();
+
+  useEffect(() => {
+    if (!userInterface) {
+      tab.setSelectedIndex(0);
+    }
+  }, [userInterface]);
+
+  return null;
+};

--- a/src/features/handlers/components/UserInterface.tsx
+++ b/src/features/handlers/components/UserInterface.tsx
@@ -1,5 +1,6 @@
+import { useTabsContext } from '@chakra-ui/react';
 import { DialogType } from '@metamask/rpc-methods';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 
 import {
   AlertDialog,
@@ -12,6 +13,12 @@ import { getUserInterface, resolveUserInterface } from '../../simulation';
 export const UserInterface: FunctionComponent = () => {
   const dispatch = useDispatch();
   const ui = useSelector(getUserInterface);
+  const tab = useTabsContext();
+
+  useEffect(() => {
+    tab.setSelectedIndex(1);
+  }, []);
+
   if (!ui) {
     return null;
   }


### PR DESCRIPTION
- When a UI is shown, switch to UI tab.
- When UI is closed, hide UI tab, and switch back to response tab.
- When page is changed, go back to initial tabs.