### PR TITLE
Only publish latest commit to GitHub Pages when pushing multiple commits

### DIFF
--- a/.github/workflows/publish-pr-site.yml
+++ b/.github/workflows/publish-pr-site.yml
@@ -1,11 +1,14 @@
 name: Publish pull request branch site to GitHub Pages
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:
       - opened
       - synchronize
-      - closed
 
 jobs:
   publish-to-gh-pages:


### PR DESCRIPTION
When pushing multiple commits shortly after eachother, CI could fail because the `gh-pages` wasn't up to date. This prevents it by cancelling the previous workflow instead.