### PR TITLE
Add transaction preset buttons

### DIFF
--- a/src/components/Prefill.tsx
+++ b/src/components/Prefill.tsx
@@ -17,6 +17,10 @@ export const Prefill: FunctionComponent<PrefillProps> = ({
     fontSize="xs"
     fontFamily="code"
     borderRadius="xl"
+    background="background.alternative"
+    _hover={{
+      background: 'info.muted',
+    }}
     {...props}
   >
     {children}

--- a/src/features/handlers/components/Handler.tsx
+++ b/src/features/handlers/components/Handler.tsx
@@ -51,7 +51,12 @@ export const Handler: FunctionComponent = () => {
               flex="1"
               overflow="hidden"
             >
-              <TabPanel display="flex" flexDirection="column" flex="1">
+              <TabPanel
+                display="flex"
+                flexDirection="column"
+                flex="1"
+                overflowY="auto"
+              >
                 <Outlet />
               </TabPanel>
               <TabPanel

--- a/src/features/handlers/transactions/components/Request.tsx
+++ b/src/features/handlers/transactions/components/Request.tsx
@@ -17,6 +17,7 @@ import { useDispatch, useSelector } from '../../../../hooks';
 import { sendRequest } from '../../../simulation';
 import { getTransactionRequest } from '../slice';
 import { TransactionFormData, hexlifyTransactionData } from '../utils';
+import { TransactionPrefills } from './TransactionPrefills';
 
 const PLACEHOLDERS = {
   chainId: 'eip155:1',
@@ -47,6 +48,7 @@ export const Request: FunctionComponent = () => {
   const {
     handleSubmit,
     register,
+    setValue,
     formState: { errors },
   } = useForm<TransactionFormData>({
     defaultValues: {
@@ -78,6 +80,19 @@ export const Request: FunctionComponent = () => {
     );
   };
 
+  const handlePrefill = (prefill: TransactionFormData) => {
+    setValue('chainId', prefill.chainId);
+    setValue('transactionOrigin', prefill.transactionOrigin);
+    setValue('from', prefill.from);
+    setValue('to', prefill.to);
+    setValue('value', prefill.value);
+    setValue('data', prefill.data);
+    setValue('gas', prefill.gas);
+    setValue('maxFeePerGas', prefill.maxFeePerGas);
+    setValue('maxPriorityFeePerGas', prefill.maxPriorityFeePerGas);
+    setValue('nonce', prefill.nonce);
+  };
+
   return (
     <Flex
       as="form"
@@ -87,6 +102,8 @@ export const Request: FunctionComponent = () => {
       onSubmit={handleSubmit(onSubmit)}
       id="request-form"
     >
+      <TransactionPrefills onClick={handlePrefill} />
+
       <Flex gap="2">
         <FormControl isInvalid={Boolean(errors.chainId)}>
           <FormLabel htmlFor="chainId">Chain ID</FormLabel>

--- a/src/features/handlers/transactions/components/Request.tsx
+++ b/src/features/handlers/transactions/components/Request.tsx
@@ -161,7 +161,7 @@ export const Request: FunctionComponent = () => {
             fontFamily="code"
             {...register('value')}
           />
-          <InputRightAddon children="ETH" />
+          <InputRightAddon children="ETH" fontSize="sm" />
         </InputGroup>
 
         <FormErrorMessage>{errors.value?.message}</FormErrorMessage>
@@ -201,7 +201,7 @@ export const Request: FunctionComponent = () => {
               fontFamily="code"
               {...register('maxFeePerGas')}
             />
-            <InputRightAddon children="GWEI" />
+            <InputRightAddon children="GWEI" fontSize="sm" />
           </InputGroup>
 
           <FormErrorMessage>{errors.maxFeePerGas?.message}</FormErrorMessage>
@@ -218,7 +218,7 @@ export const Request: FunctionComponent = () => {
               fontFamily="code"
               {...register('maxPriorityFeePerGas')}
             />
-            <InputRightAddon children="GWEI" />
+            <InputRightAddon children="GWEI" fontSize="sm" />
           </InputGroup>
 
           <FormErrorMessage>

--- a/src/features/handlers/transactions/components/TransactionPrefill.test.tsx
+++ b/src/features/handlers/transactions/components/TransactionPrefill.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '../../../../utils';
+import { TRANSACTION_PRESETS } from '../presets';
+import { TransactionPrefill } from './TransactionPrefill';
+
+describe('TransactionPrefill', () => {
+  it('renders', () => {
+    expect(() =>
+      render(
+        <TransactionPrefill
+          name="ERC-20"
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          {...TRANSACTION_PRESETS[0]!.transaction}
+          onClick={jest.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/features/handlers/transactions/components/TransactionPrefill.tsx
+++ b/src/features/handlers/transactions/components/TransactionPrefill.tsx
@@ -1,0 +1,25 @@
+import { FunctionComponent } from 'react';
+
+import { Prefill } from '../../../../components';
+import { TransactionFormData } from '../utils';
+
+export type TransactionPrefillProps = TransactionFormData & {
+  name: string;
+  onClick: (prefill: TransactionFormData) => void;
+};
+
+export const TransactionPrefill: FunctionComponent<TransactionPrefillProps> = ({
+  name,
+  onClick,
+  ...transaction
+}) => {
+  const handleClick = () => {
+    onClick(transaction);
+  };
+
+  return (
+    <Prefill cursor="pointer" onClick={handleClick}>
+      {name}
+    </Prefill>
+  );
+};

--- a/src/features/handlers/transactions/components/TransactionPrefills.test.tsx
+++ b/src/features/handlers/transactions/components/TransactionPrefills.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '../../../../utils';
+import { TransactionPrefills } from './TransactionPrefills';
+
+describe('TransactionPrefills', () => {
+  it('renders', () => {
+    expect(() =>
+      render(<TransactionPrefills onClick={jest.fn()} />),
+    ).not.toThrow();
+  });
+});

--- a/src/features/handlers/transactions/components/TransactionPrefills.tsx
+++ b/src/features/handlers/transactions/components/TransactionPrefills.tsx
@@ -1,0 +1,30 @@
+import { Box, Flex, Text } from '@chakra-ui/react';
+import { FunctionComponent } from 'react';
+
+import { TRANSACTION_PRESETS } from '../presets';
+import { TransactionFormData } from '../utils';
+import { TransactionPrefill } from './TransactionPrefill';
+
+export type TransactionPrefillsProps = {
+  onClick: (prefill: TransactionFormData) => void;
+};
+
+export const TransactionPrefills: FunctionComponent<
+  TransactionPrefillsProps
+> = ({ onClick }) => (
+  <Box marginBottom="4">
+    <Text fontWeight="500" fontSize="xs" marginBottom="1">
+      Transaction presets
+    </Text>
+    <Flex gap="2">
+      {TRANSACTION_PRESETS.map(({ name, transaction }, index) => (
+        <TransactionPrefill
+          name={name}
+          {...transaction}
+          key={`transaction-prefill-${index}`}
+          onClick={onClick}
+        />
+      ))}
+    </Flex>
+  </Box>
+);

--- a/src/features/handlers/transactions/components/index.ts
+++ b/src/features/handlers/transactions/components/index.ts
@@ -1,1 +1,2 @@
 export * from './Request';
+export * from './TransactionPrefills';

--- a/src/features/handlers/transactions/presets.ts
+++ b/src/features/handlers/transactions/presets.ts
@@ -1,0 +1,69 @@
+import { TransactionFormData } from './utils';
+
+export type TransactionPreset = {
+  name: string;
+  transaction: TransactionFormData;
+};
+
+export const TRANSACTION_PRESETS: TransactionPreset[] = [
+  {
+    name: 'ERC-20',
+    transaction: {
+      transactionOrigin: 'metamask.io',
+      chainId: 'eip155:1',
+      from: '0xa9d29f1acd75f93815f48011e2ac347ff164c7f4',
+      to: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      value: '0',
+      gas: '77727',
+      nonce: '0',
+      maxFeePerGas: '120',
+      maxPriorityFeePerGas: '0.24',
+      data: '0xa9059cbb000000000000000000000000dde3d2ed021aa02ff90110df1beb708894b4a4e9000000000000000000000000000000000000000000000002b5e3af16b1880000',
+    },
+  },
+  {
+    name: 'ERC-721',
+    transaction: {
+      transactionOrigin: 'metamask.io',
+      chainId: 'eip155:1',
+      from: '0x71ee35256e47ae7b80c4b986cb6923027f8bd8b8',
+      to: '0xe42cad6fc883877a76a26a16ed92444ab177e306',
+      value: '0',
+      gas: '93439',
+      nonce: '0',
+      maxFeePerGas: '60.9',
+      maxPriorityFeePerGas: '0.094',
+      data: '0x23b872dd00000000000000000000000071ee35256e47ae7b80c4b986cb6923027f8bd8b80000000000000000000000009d311dd340fdcfefdb0b5742bd9012db4c9454cb000000000000000000000000000000000000000000000000000000000003989b',
+    },
+  },
+  {
+    name: 'ERC-1155',
+    transaction: {
+      transactionOrigin: 'metamask.io',
+      chainId: 'eip155:1',
+      from: '0x970b9713268ffa52b41021e8cc68e612cfcc43b4',
+      to: '0x760c862191ebd06fe91ec76f7e8b7356308489e2',
+      value: '0',
+      gas: '56971',
+      nonce: '0',
+      maxFeePerGas: '15.65',
+      maxPriorityFeePerGas: '0',
+      data: '0xf242432a000000000000000000000000970b9713268ffa52b41021e8cc68e612cfcc43b4000000000000000000000000e828abd66d651cae1c1ba353995241fc3e5a336c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+    },
+  },
+  {
+    name: 'Ether',
+    transaction: {
+      transactionOrigin: 'metamask.io',
+      chainId: 'eip155:1',
+      from: '0xaf50a1b549d2cc59f9d9cc405759096467bb0390',
+      to: '0x4bbeeb066ed09b7aed07bf39eee0460dfa261520',
+      value: '0.003',
+      gas: '21000',
+      nonce: '0',
+      maxFeePerGas: '32.22',
+      maxPriorityFeePerGas: '2.6',
+      data: '',
+    },
+  },
+];


### PR DESCRIPTION
This adds transaction presets for ERC-20, ERC-721, ERC-1155, and Ether transactions. It also fixes some minor styling issues.